### PR TITLE
Update embedded graphics to version 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
-name = "ili9341"
-version = "0.1.7"
-description = "A platform agnostic driver to interface with the ILI9341 (ald ILI9340C) TFT LCD display"
 authors = ["Yuri Iozzelli <y.iozzelli@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]
+description = "A platform agnostic driver to interface with the ILI9341 (ald ILI9340C) TFT LCD display"
 keywords = ["embedded-hal-driver", "display", "LCD"]
 license = "MIT OR Apache-2.0"
+name = "ili9341"
 repository = "https://github.com/yuri91/ili9341-rs"
-
-
+version = "0.1.7"
 [dependencies]
 embedded-hal = "0.2.1"
 
 [dependencies.embedded-graphics]
-version = "0.1.1"
 optional = true
+version = "0.4.4"
 
 [features]
 default = ["graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ embedded-hal = "0.2.1"
 
 [dependencies.embedded-graphics]
 optional = true
-version = "0.4.4"
+version = "0.4.7"
 
 [features]
 default = ["graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
+name = "ili9341"
+version = "0.1.7"
+description = "A platform agnostic driver to interface with the ILI9341 (ald ILI9340C) TFT LCD display"
 authors = ["Yuri Iozzelli <y.iozzelli@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]
-description = "A platform agnostic driver to interface with the ILI9341 (ald ILI9340C) TFT LCD display"
 keywords = ["embedded-hal-driver", "display", "LCD"]
 license = "MIT OR Apache-2.0"
-name = "ili9341"
 repository = "https://github.com/yuri91/ili9341-rs"
-version = "0.1.7"
+
+
 [dependencies]
 embedded-hal = "0.2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,12 +277,12 @@ where
 }
 
 #[cfg(feature = "graphics")]
-use embedded_graphics::Drawing;
-#[cfg(feature = "graphics")]
 use embedded_graphics::drawable;
+#[cfg(feature = "graphics")]
+use embedded_graphics::{drawable::Pixel, pixelcolor::PixelColorU16, Drawing};
 
 #[cfg(feature = "graphics")]
-impl<E, SPI, CS, DC, RESET> Drawing for Ili9341<SPI, CS, DC, RESET>
+impl<E, SPI, CS, DC, RESET> Drawing<PixelColorU16> for Ili9341<SPI, CS, DC, RESET>
 where
     SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
     CS: OutputPin,
@@ -292,16 +292,21 @@ where
 {
     fn draw<T>(&mut self, item_pixels: T)
     where
-        T: Iterator<Item = drawable::Pixel>,
+        T: Iterator<Item = drawable::Pixel<PixelColorU16>>,
     {
-        for (pos, color) in item_pixels {
+        for Pixel(pos, color) in item_pixels {
             self.draw_raw(
                 pos.0 as u16,
                 pos.1 as u16,
                 pos.0 as u16,
                 pos.1 as u16,
-                if color == 0 { &[0xff,0xff] } else { &[0,0] },
-            ).expect("Failed to communicate with device");
+                if color == PixelColorU16(0) {
+                    &[0xff, 0xff]
+                } else {
+                    &[0, 0]
+                },
+            )
+            .expect("Failed to communicate with device");
         }
     }
 }


### PR DESCRIPTION
A lot has changed since 0.1.1 🙂 this PR just bumps the dependency and fixes the library integration to make it work/compile again. Tested on an actual display controlled by an STM32F103 "Blue Pill".