### PR TITLE
Generic interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["embedded-hal-driver", "display", "LCD"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yuri91/ili9341-rs"
+edition = "2018"
 
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ where
     where
         T: IntoIterator<Item = drawable::Pixel<Rgb565>>,
     {
-        const BUF_SIZE: usize = 64;
+        const BUF_SIZE: usize = 32;
 
         let mut row: [u16; BUF_SIZE] = [0; BUF_SIZE];
         let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,24 @@ use hal::spi::{Mode, Phase, Polarity};
 use core::fmt::Debug;
 use core::iter::IntoIterator;
 
+/// Trait representing the interface to the hardware.
+///
+/// Intended to abstract the various buses (SPI, MPU 8/9/16-bit) from the Controller code.
+pub trait Interface {
+    type Error;
+
+    /// Sends a command with a sequence of 8-bit arguments
+    ///
+    /// Mostly used for sending configuration commands
+    fn write(&mut self, command: u8, data: &[u8]) -> Result<(), Self::Error>;
+
+    /// Sends a command with a sequence of 16-bit data words
+    ///
+    /// Mostly used for sending MemoryWrite command and other commands
+    /// with 16-bit arguments
+    fn write_iter(&mut self, command: u8, data: impl IntoIterator<Item = u16>) -> Result<(), Self::Error>;
+}
+
 /// SPI mode
 pub const MODE: Mode = Mode {
     polarity: Polarity::IdleLow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
 #![no_std]
 
-extern crate embedded_hal as hal;
-
 #[cfg(feature = "graphics")]
 extern crate embedded_graphics;
 
-use hal::blocking::delay::DelayMs;
-use hal::blocking::spi::{Write, Transfer};
-use hal::digital::v2::OutputPin;
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::spi::{Write, Transfer};
+use embedded_hal::digital::v2::OutputPin;
 
 use core::fmt::Debug;
 use core::iter::IntoIterator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,18 +165,22 @@ impl<SpiE, PinE, IFACE, RESET> Ili9341<IFACE, RESET>
         delay.delay_ms(200);
         Ok(())
     }
+
     fn command(&mut self, cmd: Command, args: &[u8]) -> Result<(), Error<SpiE, PinE>> {
         self.interface.write(cmd as u8, args)
     }
+
     fn write_iter<I: IntoIterator<Item = u16>>(
         &mut self,
         data: I,
     ) -> Result<(), Error<SpiE, PinE>> {
         self.interface.write_iter(Command::MemoryWrite as u8, data)
     }
+
     fn write_raw(&mut self, data: &[u8]) -> Result<(), Error<SpiE, PinE>> {
         self.interface.write(Command::MemoryWrite as u8, data)
     }
+
     fn set_window(&mut self, x0: u16, y0: u16, x1: u16, y1: u16) -> Result<(), Error<SpiE, PinE>> {
         self.command(
             Command::ColumnAddressSet,
@@ -198,6 +202,7 @@ impl<SpiE, PinE, IFACE, RESET> Ili9341<IFACE, RESET>
         )?;
         Ok(())
     }
+
     /// Draw a rectangle on the screen, represented by top-left corner (x0, y0)
     /// and bottom-right corner (x1, y1).
     ///
@@ -218,6 +223,7 @@ impl<SpiE, PinE, IFACE, RESET> Ili9341<IFACE, RESET>
         self.set_window(x0, y0, x1, y1)?;
         self.write_iter(data)
     }
+
     /// Draw a rectangle on the screen, represented by top-left corner (x0, y0)
     /// and bottom-right corner (x1, y1).
     ///
@@ -239,6 +245,7 @@ impl<SpiE, PinE, IFACE, RESET> Ili9341<IFACE, RESET>
         self.set_window(x0, y0, x1, y1)?;
         self.write_raw(data)
     }
+
     /// Change the orientation of the screen
     pub fn set_orientation(&mut self, mode: Orientation) -> Result<(), Error<SpiE, PinE>> {
         match mode {
@@ -264,10 +271,12 @@ impl<SpiE, PinE, IFACE, RESET> Ili9341<IFACE, RESET>
             }
         }
     }
+
     /// Get the current screen width. It can change based on the current orientation
     pub fn width(&self) -> usize {
         self.width
     }
+
     /// Get the current screen heighth. It can change based on the current orientation
     pub fn height(&self) -> usize {
         self.height

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -41,10 +41,10 @@ impl<SPI, CS, DC, SpiE, PinE> Interface for SpiInterface<SPI, CS, DC>
         self.cs.set_low().map_err(Error::OutputPin)?;
 
         self.dc.set_low().map_err(Error::OutputPin)?;
-        self.spi.write(&[command]).map_err(Error::Spi)?;
+        self.spi.write(&[command]).map_err(Error::Interface)?;
 
         self.dc.set_high().map_err(Error::OutputPin)?;
-        self.spi.write(data).map_err(Error::Spi)?;
+        self.spi.write(data).map_err(Error::Interface)?;
 
         self.cs.set_high().map_err(Error::OutputPin)?;
         Ok(())
@@ -54,11 +54,11 @@ impl<SPI, CS, DC, SpiE, PinE> Interface for SpiInterface<SPI, CS, DC>
         self.cs.set_low().map_err(Error::OutputPin)?;
 
         self.dc.set_low().map_err(Error::OutputPin)?;
-        self.spi.write(&[command]).map_err(Error::Spi)?;
+        self.spi.write(&[command]).map_err(Error::Interface)?;
 
         self.dc.set_high().map_err(Error::OutputPin)?;
         for w in data.into_iter() {
-            self.spi.write(&w.to_be_bytes()).map_err(Error::Spi)?;
+            self.spi.write(&w.to_be_bytes()).map_err(Error::Interface)?;
         }
 
         self.cs.set_high().map_err(Error::OutputPin)?;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,7 +1,7 @@
-use super::hal::blocking::spi;
-use super::hal::spi::{Mode, Phase, Polarity};
-use super::hal::digital::v2::OutputPin;
-use super::{Interface, Error};
+use embedded_hal::blocking::spi;
+use embedded_hal::spi::{Mode, Phase, Polarity};
+use embedded_hal::digital::v2::OutputPin;
+use crate::{Interface, Error};
 
 /// SPI mode
 pub const MODE: Mode = Mode {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,67 @@
+use super::hal::blocking::spi;
+use super::hal::spi::{Mode, Phase, Polarity};
+use super::hal::digital::v2::OutputPin;
+use super::{Interface, Error};
+
+/// SPI mode
+pub const MODE: Mode = Mode {
+    polarity: Polarity::IdleLow,
+    phase: Phase::CaptureOnFirstTransition,
+};
+
+/// `Interface` implementation for SPI interfaces
+pub struct SpiInterface<SPI, CS, DC> {
+    spi: SPI,
+    cs: CS,
+    dc: DC,
+}
+
+impl<SPI, CS, DC, SpiE, PinE> SpiInterface<SPI, CS, DC>
+    where SPI: spi::Transfer<u8, Error = SpiE> + spi::Write<u8, Error = SpiE>,
+          CS: OutputPin<Error = PinE>,
+          DC: OutputPin<Error = PinE>,
+{
+    pub fn new(spi: SPI, cs: CS, dc: DC) -> Self {
+        Self {
+            spi,
+            cs,
+            dc,
+        }
+    }
+}
+
+impl<SPI, CS, DC, SpiE, PinE> Interface for SpiInterface<SPI, CS, DC>
+    where SPI: spi::Transfer<u8, Error = SpiE> + spi::Write<u8, Error = SpiE>,
+          CS: OutputPin<Error = PinE>,
+          DC: OutputPin<Error = PinE>,
+{
+    type Error = Error<SpiE, PinE>;
+
+    fn write(&mut self, command: u8, data: &[u8]) -> Result<(), Self::Error> {
+        self.cs.set_low().map_err(Error::OutputPin)?;
+
+        self.dc.set_low().map_err(Error::OutputPin)?;
+        self.spi.write(&[command]).map_err(Error::Spi)?;
+
+        self.dc.set_high().map_err(Error::OutputPin)?;
+        self.spi.write(data).map_err(Error::Spi)?;
+
+        self.cs.set_high().map_err(Error::OutputPin)?;
+        Ok(())
+    }
+
+    fn write_iter(&mut self, command: u8, data: impl IntoIterator<Item=u16>) -> Result<(), Self::Error> {
+        self.cs.set_low().map_err(Error::OutputPin)?;
+
+        self.dc.set_low().map_err(Error::OutputPin)?;
+        self.spi.write(&[command]).map_err(Error::Spi)?;
+
+        self.dc.set_high().map_err(Error::OutputPin)?;
+        for w in data.into_iter() {
+            self.spi.write(&w.to_be_bytes()).map_err(Error::Spi)?;
+        }
+
+        self.cs.set_high().map_err(Error::OutputPin)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a generic interface suitable for 8080 MCU buses like FSMC in STM32.
Additionally, pixel writes are now u16-sized, because pixels can be up to 18-bit wide, so u16 is more natural here. Implementing 16-bit bus on top of old 8-bit raw interface adds additional complications.

Note that this is a breaking change. Please test this PR against an SPI-interfaced LCD, because I do not have one.

Tested on [GD32VF103 development board](https://www.seeedstudio.com/SeeedStudio-GD32-RISC-V-kit-with-LCD-p-4303.html) from SeeedStudio. The display on this board uses 16-bit data bus for communication.

See also: https://github.com/yuri91/ili9341-rs/issues/2