### PR TITLE
Simplify and speed up initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,8 @@ where
         // and 120ms before sending Sleep Out
         delay.delay_ms(120);
 
-        ili9341.command(Command::MemoryAccessControl, &[0x48])?;
+        ili9341.set_orientation(Orientation::Portrait)?;
+
         ili9341.command(Command::PixelFormatSet, &[0x55])?;
 
         ili9341.command(Command::SleepOut, &[])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,36 +108,9 @@ where
         // and 120ms before sending Sleep Out
         delay.delay_ms(120);
 
-        ili9341.command(Command::PowerControlA, &[0x39, 0x2c, 0x00, 0x34, 0x02])?;
-        ili9341.command(Command::PowerControlB, &[0x00, 0xc1, 0x30])?;
-        ili9341.command(Command::DriverTimingControlA, &[0x85, 0x00, 0x78])?;
-        ili9341.command(Command::DriverTimingControlB, &[0x00, 0x00])?;
-        ili9341.command(Command::PowerOnSequenceControl, &[0x64, 0x03, 0x12, 0x81])?;
-        ili9341.command(Command::PumpRatioControl, &[0x20])?;
-        ili9341.command(Command::PowerControl1, &[0x23])?;
-        ili9341.command(Command::PowerControl2, &[0x10])?;
-        ili9341.command(Command::VCOMControl1, &[0x3e, 0x28])?;
-        ili9341.command(Command::VCOMControl2, &[0x86])?;
         ili9341.command(Command::MemoryAccessControl, &[0x48])?;
         ili9341.command(Command::PixelFormatSet, &[0x55])?;
-        ili9341.command(Command::FrameControlNormal, &[0x00, 0x18])?;
-        ili9341.command(Command::DisplayFunctionControl, &[0x08, 0x82, 0x27])?;
-        ili9341.command(Command::Enable3G, &[0x00])?;
         ili9341.command(Command::GammaSet, &[0x01])?;
-        ili9341.command(
-            Command::PositiveGammaCorrection,
-            &[
-                0x0f, 0x31, 0x2b, 0x0c, 0x0e, 0x08, 0x4e, 0xf1, 0x37, 0x07, 0x10, 0x03, 0x0e, 0x09,
-                0x00,
-            ],
-        )?;
-        ili9341.command(
-            Command::NegativeGammaCorrection,
-            &[
-                0x00, 0x0e, 0x14, 0x03, 0x11, 0x07, 0x31, 0xc1, 0x48, 0x08, 0x0f, 0x0c, 0x31, 0x36,
-                0x0f,
-            ],
-        )?;
 
         ili9341.command(Command::SleepOut, &[])?;
 
@@ -272,24 +245,9 @@ mod graphics;
 #[derive(Clone, Copy)]
 enum Command {
     SoftwareReset = 0x01,
-    PowerControlA = 0xcb,
-    PowerControlB = 0xcf,
-    DriverTimingControlA = 0xe8,
-    DriverTimingControlB = 0xea,
-    PowerOnSequenceControl = 0xed,
-    PumpRatioControl = 0xf7,
-    PowerControl1 = 0xc0,
-    PowerControl2 = 0xc1,
-    VCOMControl1 = 0xc5,
-    VCOMControl2 = 0xc7,
     MemoryAccessControl = 0x36,
     PixelFormatSet = 0x3a,
-    FrameControlNormal = 0xb1,
-    DisplayFunctionControl = 0xb6,
-    Enable3G = 0xf2,
     GammaSet = 0x26,
-    PositiveGammaCorrection = 0xe0,
-    NegativeGammaCorrection = 0xe1,
     SleepOut = 0x11,
     DisplayOn = 0x29,
     ColumnAddressSet = 0x2a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ where
 
         ili9341.command(Command::MemoryAccessControl, &[0x48])?;
         ili9341.command(Command::PixelFormatSet, &[0x55])?;
-        ili9341.command(Command::GammaSet, &[0x01])?;
 
         ili9341.command(Command::SleepOut, &[])?;
 
@@ -247,7 +246,6 @@ enum Command {
     SoftwareReset = 0x01,
     MemoryAccessControl = 0x36,
     PixelFormatSet = 0x3a,
-    GammaSet = 0x26,
     SleepOut = 0x11,
     DisplayOn = 0x29,
     ColumnAddressSet = 0x2a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ where
 
         ili9341.set_orientation(Orientation::Portrait)?;
 
+        // Set pixel format to 16 bits per pixel
         ili9341.command(Command::PixelFormatSet, &[0x55])?;
 
         ili9341.command(Command::SleepOut, &[])?;


### PR DESCRIPTION
After spending quite a bit of time reading the datasheet, I am pretty sure these are the minimum required delays.

I also removed all of the "extended" commands. Some (most?) display modules are configured to ignore these commands, and the ones that don't should still work fine with their default settings.

Before: 920 milliseconds
After: 131 milliseconds

Tested on an STM32F103 with an 8 bit parallel bus.