### PR TITLE
Move `::spi::MODE` to `::SPI_MODE`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use core::iter::once;
 use display_interface::DataFormat::{U16BEIter, U8Iter};
 use display_interface::WriteOnlyDataCommand;
 
-pub mod spi;
+pub use embedded_hal::spi::MODE_0 as SPI_MODE;
 
 /// Trait representing the interface to the hardware.
 ///

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,7 +1,0 @@
-use embedded_hal::spi::{Mode, Phase, Polarity};
-
-/// SPI mode
-pub const MODE: Mode = Mode {
-    polarity: Polarity::IdleLow,
-    phase: Phase::CaptureOnFirstTransition,
-};


### PR DESCRIPTION
We don't need a whole module for just one const